### PR TITLE
Set contentMode to Redraw

### DIFF
--- a/Pod/Classes/GrowingTextView.swift
+++ b/Pod/Classes/GrowingTextView.swift
@@ -51,6 +51,9 @@ import UIKit
     
     // Listen to UITextView notification to handle trimming, placeholder and maximum length
     private func commonInit() {
+    
+        self.contentMode = .Redraw
+    
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "textDidChange:", name: UITextViewTextDidChangeNotification, object: self)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "textDidEndEditing:", name: UITextViewTextDidEndEditingNotification, object: self)
     }


### PR DESCRIPTION
During rotation, the placeholder text gets stretched out. This forces the view to redraw itself when the frame size changes.