### PR TITLE
"PlaceHolder" changed to "Placeholder"

### DIFF
--- a/Example/GrowingTextView/Base.lproj/Main.storyboard
+++ b/Example/GrowingTextView/Base.lproj/Main.storyboard
@@ -139,7 +139,7 @@
                                             <userDefinedRuntimeAttribute type="number" keyPath="maxHeight">
                                                 <real key="value" value="70"/>
                                             </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="placeHolder" value="Say something..."/>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Say something..."/>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <outlet property="delegate" destination="MoA-Hl-V8R" id="oZX-Qv-oXj"/>
@@ -222,7 +222,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="placeHolder" value="Say something..."/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Say something..."/>
                                     <userDefinedRuntimeAttribute type="number" keyPath="maxLength">
                                         <integer key="value" value="200"/>
                                     </userDefinedRuntimeAttribute>

--- a/Example/GrowingTextView/Base.lproj/Main.storyboard
+++ b/Example/GrowingTextView/Base.lproj/Main.storyboard
@@ -216,7 +216,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="KoN-fe-F8s" customClass="GrowingTextView" customModule="GrowingTextView">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="KoN-fe-F8s" customClass="GrowingTextView" customModule="GrowingTextView">
                                 <rect key="frame" x="8" y="144" width="359" height="33"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>

--- a/Example/GrowingTextView/Example1.swift
+++ b/Example/GrowingTextView/Example1.swift
@@ -31,8 +31,8 @@ class Example1: UIViewController {
         textView.maxLength = 200
         textView.maxHeight = 70
         textView.trimWhiteSpaceWhenEndEditing = true
-        textView.placeHolder = "Say something..."
-        textView.placeHolderColor = UIColor(white: 0.8, alpha: 1.0)
+        textView.placeholder = "Say something..."
+        textView.placeholderColor = UIColor(white: 0.8, alpha: 1.0)
         textView.font = UIFont.systemFont(ofSize: 15)
         textView.translatesAutoresizingMaskIntoConstraints = false
         inputToolbar.addSubview(textView)

--- a/Example/GrowingTextView/Example3.swift
+++ b/Example/GrowingTextView/Example3.swift
@@ -18,7 +18,7 @@ class Example3: UIViewController {
 
         // *** Customize GrowingTextView ***
         textView.layer.cornerRadius = 4.0
-        textView.placeHolder = "Say something..."
+        textView.placeholder = "Say something..."
         textView.font = UIFont.systemFont(ofSize: 15)
         textView.minHeight = 30
         textView.maxHeight = 100

--- a/Pod/Classes/GrowingTextView.swift
+++ b/Pod/Classes/GrowingTextView.swift
@@ -33,10 +33,10 @@ open class GrowingTextView: UITextView {
     @IBInspectable open var maxHeight: CGFloat = 0 {
         didSet { forceLayoutSubviews() }
     }
-    @IBInspectable open var placeHolder: String? {
+    @IBInspectable open var placeholder: String? {
         didSet { setNeedsDisplay() }
     }
-    @IBInspectable open var placeHolderColor: UIColor = UIColor(white: 0.8, alpha: 1.0) {
+    @IBInspectable open var placeholderColor: UIColor = UIColor(white: 0.8, alpha: 1.0) {
         didSet { setNeedsDisplay() }
     }
     @IBInspectable open var attributedPlaceHolder: NSAttributedString? {
@@ -144,24 +144,24 @@ open class GrowingTextView: UITextView {
             let yValue = textContainerInset.top
             let width = rect.size.width - xValue - textContainerInset.right
             let height = rect.size.height - yValue - textContainerInset.bottom
-            let placeHolderRect = CGRect(x: xValue, y: yValue, width: width, height: height)
+            let placeholderRect = CGRect(x: xValue, y: yValue, width: width, height: height)
             
             if let attributedPlaceholder = attributedPlaceHolder {
                 // Prefer to use attributedPlaceHolder
-                attributedPlaceholder.draw(in: placeHolderRect)
-            } else if let placeHolder = placeHolder {
-                // Otherwise user placeHolder and inherit `text` attributes
+                attributedPlaceholder.draw(in: placeholderRect)
+            } else if let placeholder = placeholder {
+                // Otherwise user placeholder and inherit `text` attributes
                 let paragraphStyle = NSMutableParagraphStyle()
                 paragraphStyle.alignment = textAlignment
                 var attributes: [NSAttributedStringKey: Any] = [
-                    .foregroundColor: placeHolderColor,
+                    .foregroundColor: placeholderColor,
                     .paragraphStyle: paragraphStyle
                 ]
                 if let font = font {
                     attributes[.font] = font
                 }
                 
-                placeHolder.draw(in: placeHolderRect, withAttributes: attributes)
+                placeholder.draw(in: placeholderRect, withAttributes: attributes)
             }
         }
     }

--- a/Pod/Classes/GrowingTextView.swift
+++ b/Pod/Classes/GrowingTextView.swift
@@ -39,7 +39,7 @@ open class GrowingTextView: UITextView {
     @IBInspectable open var placeholderColor: UIColor = UIColor(white: 0.8, alpha: 1.0) {
         didSet { setNeedsDisplay() }
     }
-    @IBInspectable open var attributedPlaceHolder: NSAttributedString? {
+    @IBInspectable open var attributedPlaceholder: NSAttributedString? {
         didSet { setNeedsDisplay() }
     }
     
@@ -146,8 +146,8 @@ open class GrowingTextView: UITextView {
             let height = rect.size.height - yValue - textContainerInset.bottom
             let placeholderRect = CGRect(x: xValue, y: yValue, width: width, height: height)
             
-            if let attributedPlaceholder = attributedPlaceHolder {
-                // Prefer to use attributedPlaceHolder
+            if let attributedPlaceholder = attributedPlaceholder {
+                // Prefer to use attributedPlaceholder
                 attributedPlaceholder.draw(in: placeholderRect)
             } else if let placeholder = placeholder {
                 // Otherwise user placeholder and inherit `text` attributes

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ override func viewDidLoad() {
 | ------------------------------ | ------------------- | ---------------------------------------- | ------------------------------- |
 | *maxLength*                    | Int                 | Maximum text length. Exceeded text will be trimmed. 0 means no limit. | *0*                             |
 | *trimWhiteSpaceWhenEndEditing* | Bool                | Trim white space and new line characters when textview did end editing. | *true*                          |
-| *placeHolder*                  | String?             | PlaceHolder text.                        | *nil*                           |
-| *placeHolderColor*             | UIColor             | PlaceHolder text color.                  | UIColor(white: 0.8, alpha: 1.0) |
+| *placeholder*                  | String?             | PlaceHolder text.                        | *nil*                           |
+| *placeholderColor*             | UIColor             | PlaceHolder text color.                  | UIColor(white: 0.8, alpha: 1.0) |
 | *attributedPlaceHolder*        | NSAttributedString? | Attributed PlaceHolder text.             | *nil*                           |
 | *minHeight*                    | CGFloat             | Minimum height of textview.              | *0.0*                           |
 | *maxHeight*                    | CGFloat             | Maximum height of textview.              | *0.0*                           |
@@ -88,8 +88,8 @@ override func viewDidLoad() {
 ```swift
 textView.maxLength = 140
 textView.trimWhiteSpaceWhenEndEditing = false
-textView.placeHolder = "Say something..."
-textView.placeHolderColor = UIColor(white: 0.8, alpha: 1.0)
+textView.placeholder = "Say something..."
+textView.placeholderColor = UIColor(white: 0.8, alpha: 1.0)
 textView.minHeight = 25.0
 textView.maxHeight = 70.0
 textView.backgroundColor = UIColor.whiteColor()

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ override func viewDidLoad() {
 | ------------------------------ | ------------------- | ---------------------------------------- | ------------------------------- |
 | *maxLength*                    | Int                 | Maximum text length. Exceeded text will be trimmed. 0 means no limit. | *0*                             |
 | *trimWhiteSpaceWhenEndEditing* | Bool                | Trim white space and new line characters when textview did end editing. | *true*                          |
-| *placeholder*                  | String?             | PlaceHolder text.                        | *nil*                           |
-| *placeholderColor*             | UIColor             | PlaceHolder text color.                  | UIColor(white: 0.8, alpha: 1.0) |
-| *attributedPlaceHolder*        | NSAttributedString? | Attributed PlaceHolder text.             | *nil*                           |
+| *placeholder*                  | String?             | Placeholder text.                        | *nil*                           |
+| *placeholderColor*             | UIColor             | Placeholder text color.                  | UIColor(white: 0.8, alpha: 1.0) |
+| *attributedPlaceholder*        | NSAttributedString? | Attributed Placeholder text.             | *nil*                           |
 | *minHeight*                    | CGFloat             | Minimum height of textview.              | *0.0*                           |
 | *maxHeight*                    | CGFloat             | Maximum height of textview.              | *0.0*                           |
 


### PR DESCRIPTION
Placeholder is one word and should not camelcase.
You can check it with apple's native "textField.placeholder" spell.